### PR TITLE
New notes: Distinguish between abort and empty note name

### DIFF
--- a/src/newNote.js
+++ b/src/newNote.js
@@ -62,7 +62,13 @@ function createNote(noteFolder) {
   })
 
   inputBoxPromise.then(noteName => {
-    if (noteName == null || !noteName) {
+    // Check for aborting the new note dialog
+    if (noteName == null) {
+      return false
+    }
+
+    // Check for empty string but confirmation in the new note dialog
+    if (noteName == "" || !noteName) {
       noteName = defaultNoteName
     }
 


### PR DESCRIPTION
In the new note dialog, when trying to abort by hitting ESC or losing the focus, VS Notes 0.6.0 always creates a `New_note.md` in the notes folder.

This pull request aborts the creation of a new note. Only when hitting ENTER will a new note be created.