### PR TITLE
Templates supports

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ VS Notes is a simple tool that takes care of the creation and management of plai
     - [Filename Tokens](#filename-tokens)
     - [File Path Detection](#file-path-detection)
     - [Snippets](#snippets)
+    - [Templates](#templates)
     - [Tags](#tags)
     - [Custom Activity Bar Section & Explorer View](#custom-activity-bar-section--explorer-view)
     - [Commit and Push](#commit-and-push)
@@ -131,6 +132,25 @@ VSNotes understands file paths and will create folders as necessary. When prompt
 - Set `langId` to a language and `name` to `null` and a menu will open with all available snippets for your chosen language.
 - Set both `langId` and `name` to null to disable automatic snippet insertion.
 
+### Templates
+
+VS Notes adds the concept of "templates", that basically are snippets. If setted inside settings, on creating new note will ask you which template use.
+
+```
+  "vsnote_TEMPLATE_NAME": {
+    "prefix": "vsnote_TEMPLATE_NAME",
+    "body": [
+      "---",
+      "tags:",
+      "\t- meeting",
+      "---",
+      "\n# Meeting: $1 - $CURRENT_DATE/$CURRENT_MONTH/$CURRENT_YEAR\n",
+      "$2",
+    ],
+    "description": "Generic Meeting Template Note",
+  },
+```
+
 ### Tags
 [New in 0.2.0] VS Notes adds the ability to pull tags out of documents containing a [YAML](http://yaml.org/) [frontmatter block (a la jekyll's frontmatter)](https://jekyllrb.com/docs/frontmatter/). YAML frontmatter is a way to encode machine parsable data in a way that is friendly to read and write.
 
@@ -232,6 +252,9 @@ Available settings
 
   // Hide the tags section in the sidebar. Requires application restart.
   "vsnotes.treeviewHideTags": false
+
+  // Define templates names (`vsnote_TEMPLATE_NAME`)
+  "vsnotes.templates": ["meeting"],
 ```
 
 # Tips and tricks

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ VSNotes understands file paths and will create folders as necessary. When prompt
 
 ### Templates
 
-VS Notes adds the concept of "templates", that basically are snippets. If setted inside settings, on creating new note will ask you which template use.
+VS Notes adds the concept of "templates". A template is basically a snippet so to create a new template just go to: Code > Preferences > User Snippets and add your template. For example:
 
 ```
   "vsnote_TEMPLATE_NAME": {
@@ -150,6 +150,16 @@ VS Notes adds the concept of "templates", that basically are snippets. If setted
     "description": "Generic Meeting Template Note",
   },
 ```
+
+Once you create your template you have to tell VSNote you want to use your custom template, to do that just add an array of template names to your `settings.json` as below:
+
+```
+"vsnotes.templates": [
+  "TEMPLATE_NAME",
+],
+```
+
+Note that the snippets must be called `vsnote_TEMPLATE_NAME` and `TEMPLATE_NAME` is the name you setted in the `settings.json`.
 
 ### Tags
 [New in 0.2.0] VS Notes adds the ability to pull tags out of documents containing a [YAML](http://yaml.org/) [frontmatter block (a la jekyll's frontmatter)](https://jekyllrb.com/docs/frontmatter/). YAML frontmatter is a way to encode machine parsable data in a way that is friendly to read and write.

--- a/README.md
+++ b/README.md
@@ -6,23 +6,25 @@ VS Notes is a simple tool that takes care of the creation and management of plai
 
 <!-- TOC -->
 
+- [VS NOTES](#vs-notes)
 - [Demo Video](#demo-video)
 - [Repository](#repository)
 - [Features](#features)
 - [Quick Start](#quick-start)
 - [Taking Notes](#taking-notes)
-    - [Note Filename](#note-filename)
-        - [Filename Tokens](#filename-tokens)
-        - [File Path Detection](#file-path-detection)
-        - [Snippets](#snippets)
-        - [Tags](#tags)
-        - [Explorer View](#explorer-view)
-        - [Commit and Push](#commit-and-push)
+  - [Note Filename](#note-filename)
+    - [Filename Tokens](#filename-tokens)
+    - [File Path Detection](#file-path-detection)
+    - [Snippets](#snippets)
+    - [Tags](#tags)
+    - [Custom Activity Bar Section & Explorer View](#custom-activity-bar-section--explorer-view)
+    - [Commit and Push](#commit-and-push)
 - [Settings](#settings)
 - [Tips and tricks](#tips-and-tricks)
-- [Roadmap & Features](#roadmap-features)
+- [Roadmap & Features](#roadmap--features)
 - [Change log](#change-log)
 - [Contributing](#contributing)
+- [Contributors](#contributors)
 - [Reviews](#reviews)
 
 <!-- /TOC -->

--- a/package.json
+++ b/package.json
@@ -116,6 +116,16 @@
                     "default": "_",
                     "description": "Automatically convert blank spaces in title to character. To disable set to `null`."
                 },
+                "vsnotes.template": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "default": [
+                      "new_template"
+                  ],
+                  "description": "Template name."
+                },
                 "vsnotes.defaultSnippet": {
                     "type": "object",
                     "properties": {

--- a/src/newNote.js
+++ b/src/newNote.js
@@ -9,17 +9,22 @@ const {resolveHome} = require('./utils');
 // This function handles creation of a new note in default note folder
 function newNote() {
   const config = vscode.workspace.getConfiguration('vsnotes');
+  const folder = resolveHome(config.get('defaultNotePath'));
   const templates = config.get('templates');
 
-  const quickPickPromise = vscode.window.showQuickPick (templates, {
+  if (!templates || !templates.length) {
+    createNote({ folder });
+    return
+  }
+
+  vscode.window.showQuickPick (templates, {
     prompt: 'Select a template',
-    value: "default-notee",
   })
-
-  quickPickPromise.then(template => {
-    const folder = resolveHome(config.get('defaultNotePath'));
-
+  .then(template => {
+    console.log(template)
     createNote({ folder, template });
+  }, err => {
+    console.error(err);
   })
 }
 
@@ -110,13 +115,15 @@ function createNote({ folder: noteFolder, template }) {
   })
 }
 
-function createTemplate({ template }) {
+function createTemplate({ template = null }) {
   const config = vscode.workspace.getConfiguration('vsnotes');
 
   if (template != null) {
-    vscode.commands.executeCommand('editor.action.insertSnippet', ...[{ langId: 'markdown', name: `notee_${template}` }]).then(res => {
+    vscode.commands.executeCommand('editor.action.insertSnippet', ...[{ langId: 'markdown', name: `vsnote_${template}` }]).then(res => {
+      vscode.window.showInformationMessage(`Note for "${template}" created!`);
       console.log('template created: ', res)
     }, err => {
+      vscode.window.showErrorMessage('Template creation error.');
       console.error('template creation error: ', err)
     })
   } else {


### PR DESCRIPTION
Closes #33 

With this feature you can choose a template (snippets) with a prompt on note creating.

You just have to create a config:

```
"vsnotes.templates": [
  "template1",
  "template2",
  "template3",
 ],
``` 

and into your `snippets` file something like:

```
  "vsnote_template1": {
    "prefix": "vsnote_template1",
    "body": [
      "---",
      "tags:",
      "\t- tag",
      "---",
      "\n# $1 \n",
      "$2",
    ],
    "description": "Custom Template Note",
  },
```