### PR TITLE
Modify git command default statement for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ VS Notes is a simple tool that takes care of the creation and management of plai
     - [Filename Tokens](#filename-tokens)
     - [File Path Detection](#file-path-detection)
     - [Snippets](#snippets)
-    - [Templates](#templates)
+    - [Snippet selection](#snippet-selection)
     - [Tags](#tags)
     - [Custom Activity Bar Section & Explorer View](#custom-activity-bar-section--explorer-view)
     - [Commit and Push](#commit-and-push)
@@ -199,8 +199,6 @@ Access your notes no matter what you're doing. This new treeview adds a quick wa
 
 To customize the command and the default command and commit message, update the settings: `vsnotes.commitPushShellCommand` and `vsnotes.commitPushDefaultCommitMessage`.
 
-Note that this has not been tested on windows machines and may not work without modifying the command. Please test before using.
-
 # Settings
 Available settings
 
@@ -209,7 +207,7 @@ Available settings
   "vsnotes.commitPushDefaultCommitMessage": "VS Notes Commit and Push",
 
   // Shell command to execute in the note directory when the Commit and Push command is executed. The {msg} token will be replaced with the contents of an input box shown or, if empty, the default commit message.
-  "vsnotes.commitPushShellCommand": "git add -A && git commit -m '{msg}' && git push",
+  "vsnotes.commitPushShellCommand": "git add -A && git commit -m \"{msg}\" && git push",
 
   // Default title for new notes.
   "vsnotes.defaultNoteName": "New_Note",

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
                 },
                 "vsnotes.commitPushShellCommand": {
                     "type": "string",
-                    "default": "git add -A && git commit -m '{msg}' && git push",
+                    "default": "git add -A && git commit -m \"{msg}\" && git push",
                     "description": "Shell command to execute in the note directory when the Commit and Push command is executed. The {msg} token will be replaced with the contents of an input box shown or, if empty, the default commit message."
                 },
                 "vsnotes.commitPushDefaultCommitMessage": {


### PR DESCRIPTION
Thank you for awesome extension.

Btw as you write in `README.md`, on Windows the `Commit and Push` function doesn't work correctly when a commit message contains space(s) as below.

```
> git commit -m 'Hello Hello'
error: pathspec 'Hello'' did not match any file(s) known to git
```

This is because the single quotation is used in default commit command, which is `git commit -m '{msg}'`. We must use the double quotation on the Windows command prompt. Please refer the attached image.

<img width="837" alt="error_on_windows_02" src="https://user-images.githubusercontent.com/14275619/50432992-da6dba00-0918-11e9-9461-5f01c8984118.png">

I fixed this.