### PR TITLE
Allow empty tags

### DIFF
--- a/src/listTags.js
+++ b/src/listTags.js
@@ -78,7 +78,7 @@ function createTagIndex(noteFolderPath) {
           for (let i = 0; i < files.length; i++) {
             if (files[i] != null && files[i]) {
               const parsedFrontMatter = matter(files[i].contents);
-              if ('tags' in parsedFrontMatter.data) {
+              if ('tags' in parsedFrontMatter.data && parsedFrontMatter.data.tags) {
                 for (let tag of parsedFrontMatter.data.tags) {
                   if (tag in tagIndex) {
                     tagIndex[tag].push(files[i].path);

--- a/src/treeView.js
+++ b/src/treeView.js
@@ -162,7 +162,7 @@ class VSNotesTreeView  {
             for (let i = 0; i < files.length; i++) {
               if (files[i] != null && files[i]) {
                 const parsedFrontMatter = matter(files[i].contents);
-                if ('tags' in parsedFrontMatter.data) {
+                if ('tags' in parsedFrontMatter.data && parsedFrontMatter.data.tags) {
                   for (let tag of parsedFrontMatter.data.tags) {
                     if (tag in tagIndex) {
                       tagIndex[tag].push(files[i].payload);


### PR DESCRIPTION
This pull-request changes to allow following YAML.

```yaml
---
tags:
---
```

in this case, VSNotes will continue to refresh tags and keep loading icon.
