### PR TITLE
ignore broken front matter

### DIFF
--- a/src/listTags.js
+++ b/src/listTags.js
@@ -77,8 +77,8 @@ function createTagIndex(noteFolderPath) {
           let tagIndex = {};
           for (let i = 0; i < files.length; i++) {
             if (files[i] != null && files[i]) {
-              const parsedFrontMatter = matter(files[i].contents);
-              if ('tags' in parsedFrontMatter.data && parsedFrontMatter.data.tags) {
+              const parsedFrontMatter = parseFrontMatter(files[i]);
+              if (parsedFrontMatter && 'tags' in parsedFrontMatter.data && parsedFrontMatter.data.tags) {
                 for (let tag of parsedFrontMatter.data.tags) {
                   if (tag in tagIndex) {
                     tagIndex[tag].push(files[i].path);
@@ -95,4 +95,18 @@ function createTagIndex(noteFolderPath) {
         })
       })
   })
+}
+
+function parseFrontMatter(file) {
+  try {
+    const parsedFrontMatter = matter(file.contents)
+    if (!(parsedFrontMatter.data instanceof Object)) {
+      console.error('YAML front-matter is not an object: ', file.path);
+      return null;
+    }
+    return parsedFrontMatter;
+  } catch (e) {
+    console.error(file.path, e);
+    return null;
+  }
 }

--- a/src/treeView.js
+++ b/src/treeView.js
@@ -161,8 +161,8 @@ class VSNotesTreeView  {
             let tagIndex = {};
             for (let i = 0; i < files.length; i++) {
               if (files[i] != null && files[i]) {
-                const parsedFrontMatter = matter(files[i].contents);
-                if ('tags' in parsedFrontMatter.data && parsedFrontMatter.data.tags) {
+                const parsedFrontMatter = this._parseFrontMatter(files[i]);
+                if (parsedFrontMatter && 'tags' in parsedFrontMatter.data && parsedFrontMatter.data.tags) {
                   for (let tag of parsedFrontMatter.data.tags) {
                     if (tag in tagIndex) {
                       tagIndex[tag].push(files[i].payload);
@@ -190,6 +190,20 @@ class VSNotesTreeView  {
           })
         })
     });
+  }
+
+  _parseFrontMatter (file) {
+    try {
+      const parsedFrontMatter = matter(file.contents)
+      if (!(parsedFrontMatter.data instanceof Object)) {
+        console.error('YAML front-matter is not an object: ', file.path);
+        return null;
+      }
+      return parsedFrontMatter;
+    } catch (e) {
+      console.error(file.path, e);
+      return null;
+    }
   }
 }
 


### PR DESCRIPTION
This pull request will fix #48.

This will ignore following front matters:

1. parsed to String.
```yaml
---
tags
---
```

2. YAMLException occurs
```yaml
---
tags:
foo
---
```

3. Example in #60 will be also ignored because YAMLException occur. (last '-' is missing)
```yaml
---
tags:
  - bookmarks
  - links
--
```