### PR TITLE
change default snippet name

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Available settings
 // Default vscode snippet to execute after creating a note. Set both langId and name to null to disable.
 "vsnotes.defaultSnippet": {
     "langId": "markdown",
-    "name": "vsnotes"
+    "name": "vsnote_template_default"
 },
 
 // Regular expressions for file names to ignore when parsing documents in note folder.

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
                     },
                     "default": {
                         "langId": "markdown",
-                        "name": "vsnotes"
+                        "name": "vsnote_template_default"
                     },
                     "description": "Default vscode snippet to execute after creating a note. Set both langId and name to null to disable."
                 },


### PR DESCRIPTION
This PR changes default snippet name to create new notes.

Snippet names Included in VSNotes are `vsnote_template_default ` and `vsnote_template_meeting` in markdown.json.

snippet name in older version was `vsnotes`, but it was changed:
https://github.com/patleeman/VSNotes/commit/1fb703f4593527390b5c5c4a322cff5c9e4509e8#diff-872cf2c56f0295afc25a93601f6d7560R2

This PR ensures that the template will be applied when creating notes even if `vsnotes.defaultSnippet` is not set.