### PR TITLE
Updating type-def to match functionality and docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
                     "description": "Number of recent files to show when running command `List Notes`."
                 },
                 "vsnotes.noteTitleConvertSpaces": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "default": "_",
                     "description": "Automatically convert blank spaces in title to character. To disable set to `null`."
                 },


### PR DESCRIPTION
The docs sais to set this option to `null` if we want to disable it, however, the only type it accepts is a string. This fixes it, so the config-ui wont complain