### PR TITLE
Fix default note path with home path

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -48,9 +48,10 @@ function activate(context) {
 
     // Open note folder in new workspace
     let openNoteFolderDisposable = vscode.commands.registerCommand('vsnotes.openNoteFolder', () => {
-      const uri = vscode.Uri.file(vscode.workspace.getConfiguration('vsnotes').get('defaultNotePath'));
-      const folderPath = utils.resolveHome(uri)
-      return vscode.commands.executeCommand('vscode.openFolder', folderPath, true);
+      const noteFolder = vscode.workspace.getConfiguration('vsnotes').get('defaultNotePath');
+      const folderPath = utils.resolveHome(noteFolder);
+      const uri = vscode.Uri.file(folderPath)
+      return vscode.commands.executeCommand('vscode.openFolder', uri, true);
     })
     context.subscriptions.push(openNoteFolderDisposable);
 

--- a/src/search.js
+++ b/src/search.js
@@ -2,8 +2,8 @@ const vscode = require('vscode');
 const {resolveHome} = require('./utils');
 
 module.exports = async function () {
-  const uri = vscode.Uri.file(vscode.workspace.getConfiguration('vsnotes').get('defaultNotePath'));
-  const folderPath = resolveHome(uri);
+  const config = vscode.workspace.getConfiguration('vsnotes');
+  const folderPath = vscode.Uri.file(resolveHome(config.get('defaultNotePath')));
 
   // We need to check if a workspace folder is open. VSCode doesn't allow
   // findInFile if a workspace folder isn't available.


### PR DESCRIPTION
This PR fixes the bug, cannot open note folder when home path `~/` is set to the default note path.
(fixes #74)

`vscode.Uri.file()` returns object, but `utils.resolveHome()` looks to handle string.
So changed to resolve home path first, then create URI.

Also I found the same bug in note search command, fixed it together.

This is an awesome extension, so I hope this PR will help.